### PR TITLE
No more `npm install` warnings and `npm test` still passes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
   },
   "homepage": "https://github.com/AMKohn/bounceback",
   "devDependencies": {
-    "grunt": "^0.4.5",
-    "grunt-contrib-copy": "^0.7.0",
-    "grunt-contrib-uglify": "^0.6.0",
-    "istanbul": "^0.3.2",
+    "grunt": "^1.0.0",
+    "grunt-contrib-copy": "^1.0.0",
+    "grunt-contrib-uglify": "^2.0.0",
+    "istanbul": "^0.4.5",
     "lodash": "^2.4.1",
-    "mocha": "^2.0.1",
+    "mocha": "^3.2.0",
     "should": "^4.3.0"
   }
 }


### PR DESCRIPTION
Just minor updates to the package.json. Eliminates all the `npm install` warnings, especially the ones that are security concerns (admittedly, most of them are backend security risks, not applicable to this package).